### PR TITLE
Fix quotes in self.normalize regexp

### DIFF
--- a/ruaccent/ruaccent.py
+++ b/ruaccent/ruaccent.py
@@ -21,7 +21,7 @@ class RUAccent:
         self.stress_usage_predictor = StressUsagePredictorModel()
         self.yo_homograph_model = YoHomographModel()
         self.fs = HfFileSystem()
-        self.normalize = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ—.,!?:;""''(){}\[\]«»„“”-]")
+        self.normalize = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ—.,!?:;\"''(){}\[\]«»„“”-]")
         self.omograph_models_paths = {'big_poetry': '/nn/nn_omograph/big_poetry', 
                                       'medium_poetry': '/nn/nn_omograph/medium_poetry', 
                                       'small_poetry': '/nn/nn_omograph/small_poetry',


### PR DESCRIPTION
Из строки регулярного выражения
```
self.normalize = re.compile(r"[^a-zA-Z0-9\sа-яА-ЯёЁ—.,!?:;""''(){}\[\]«»„“”-]")
```
незаметно пропадали двойные кавычки ", т.к. они служат символами начала и конца строки.
Поэтому после обработки строк с двойными кавычками кавычки стирались.
Заэкранировал кавычки.
Но осталась ещё проблемка с пропадающими пробелами между тире и кавычкой. Строка типа:
```
"Он - 'наш' человек"
```
После обработки становится:
```
"+Он -'н+аш' челов+ек"
```